### PR TITLE
Read image

### DIFF
--- a/read_image.py
+++ b/read_image.py
@@ -2,7 +2,7 @@ import pds4_tools
 from PIL import Image
 
 # Read the file
-struct_list = pds4_tools.read('local-path-to-extracted-file/data/calibrated/20220129/xml-file')
+struct_list = pds4_tools.read('local-path-to-extracted-file/data/calibrated/folder-number/xml-file')
 # Extract the image from the file
 im = struct_list[0].data
 # Slice part of the image array

--- a/read_image.py
+++ b/read_image.py
@@ -1,0 +1,16 @@
+import pds4_tools
+from PIL import Image
+
+# Read the file
+struct_list = pds4_tools.read('local-path-to-extracted-file/data/calibrated/20220129/ch2_ohr_ncp_20220129T0150171705_d_img_d18.xml')
+# Extract the image from the file
+im = struct_list[0].data
+# Slice part of the image array
+image_slice = im[100000:, 11000:]
+# Display the array
+img = Image.fromarray(image_slice)
+img.save('sample.png')
+img.show()
+
+
+

--- a/read_image.py
+++ b/read_image.py
@@ -2,7 +2,7 @@ import pds4_tools
 from PIL import Image
 
 # Read the file
-struct_list = pds4_tools.read('local-path-to-extracted-file/data/calibrated/20220129/ch2_ohr_ncp_20220129T0150171705_d_img_d18.xml')
+struct_list = pds4_tools.read('local-path-to-extracted-file/data/calibrated/20220129/xml-file')
 # Extract the image from the file
 im = struct_list[0].data
 # Slice part of the image array


### PR DESCRIPTION
This script extracts image from one file and displays a slice of the whole image.  Find the xml file in the data folder of the extracted file and replace "local-path-to-extracted-file/data/calibrated/folder-number/xml-file" in the script. Dependencies are pds4_tools and PIL  libraries. 